### PR TITLE
Add sample dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:4.8.1-alpine
+WORKDIR /app
+ADD . /app
+
+RUN yarn
+RUN npm run production

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,14 @@ FROM node:4.8.1-alpine
 WORKDIR /app
 ADD . /app
 
+ENV API_HOST="https://api.tinkerware.io"
+
+EXPOSE 3000
 RUN yarn
-RUN npm run production
+RUN npm run build
+
+RUN rm -rf node_modules
+
+RUN yarn --production
+
+CMD npm run production

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "remove-dist": "rimraf ./dist",
     "production": "node tools/distServer.js",
     "prebuild": "npm run clean-dist && npm run lint && npm run test",
-    "build": "babel-node tools/build.js && node tools/distServer.js",
+    "build": "babel-node tools/build.js",
     "test-server": "npm-run-all --parallel mock-server test:watch open:test lint:watch",
     "mock-server": "node_modules/drakov/drakov -f \"api/tinkerware-blueprint/*.apib\" \"api/tinkerware-blueprint/\" -p 3100 --watch --autoOptions --header authorization --header provider-token --body key",
     "test": "mocha tools/testSetup.js \"src/**/*.spec.js\" --reporter progress",

--- a/src/constants/Hosts.js
+++ b/src/constants/Hosts.js
@@ -1,3 +1,3 @@
 export const DEVELOPMENT ="http://api.tinkerware.io";
-export const PRODUCTION ="https://api.tinkerware.io";
+export const PRODUCTION = process.env.API_HOST || "https://api.tinkerware.io";
 export const TEST ="localhost:3100";


### PR DESCRIPTION
This works as is right now, but you can't use environment variables, such as the api host.
Work to be done:

- [ ] Define the variables that need to be exposed
- [ ] Default the variables if an env variable is not supplied. 